### PR TITLE
Add --existing-python Flag for Faster Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Execute script; see options below for more information.
 |--------|-------------|
 | `--psychopy-version=`<br>`VERSION` | Specify the [PsychoPy Version](https://pypi.org/project/psychopy/#history) to install (default: `2024.1.4`). |
 | `--python-version=`<br>`[3.8\|3.9\|3.10]` | Specify the [Python Version](https://www.python.org/ftp/python) to install (default: `3.10`). |
-|  `--use-system-python` | Use installed Python instead of installing a new version. Requires choosen Python version, pip, and venv to be pre-installed and accessible in the system path. |
+| `--existing-python` | Use installed Python instead of installing a new version. Requires choosen Python version, pip, and venv to be pre-installed and accessible in the system path. |
 | `--wxpython-version=`<br>`VERSION` | Specify the [wxPython Version](https://pypi.org/project/wxPython/#history) to install (default: `4.2.2`). |
 | `--build=`<br>`[python\|wxpython\|both]` | Build Python and/or wxPython from source instead of downloading wheel/binaries. Use `both` if something does not work. |
 | `--install-dir=DIR` | Specify the installation directory (default: `$HOME`); use absolute paths without a trailing `/`. Do not use `~/`; use `/home/{user}` instead. |
@@ -78,10 +78,9 @@ Execute script; see options below for more information.
 
 **Note:**
 
-- The default version for `--psychopy-version` is set to `2024.1.4` Because new releases for Linux often introduce bugs that require manual fixes. For example `2024.2.1` has problems with opening the GUI when not installing a earlier version first.
-- `--psychopy-version` and `--wxpython-version` can take a [PyPI](https://pypi.org) version, `latest` or `git` as argument. Git versions are not recommended because they can be unstable.
-- A fast install is possible for OS, Python-version and wxpython-version combination with these [pre-compiled versions](https://github.com/wieluk/psychopy_linux_installer/blob/main/.github/build_results.md).
-- `--sudo-mode=continue` allows non-admin users to upgrade or reinstall if the correct Python version is in /usr/local/psychopy_python and all packages are installed (assuming an admin ran the program once with the same Python version).
+- Using `--existing-python`: This option speeds up the installation by skipping Python-specific dependency downloads and setup. It assumes that a compatible Python version (including `pip` and `venv`) is already installed and accessible in the system path. In future releases this option may become the default.
+- Non-Admin Installation: The `--sudo-mode=continue` option enables non-admin users to upgrade or reinstall if the required Python version and packages are already in /usr/local/psychopy_python. When used with --existing-python, this option will also work if all necessary packages are already installed. This setup assumes an administrator has previously run the installation.
+- Version Selection: The `--psychopy-version` and `--wxpython-version` options accept specific versions from [PyPI](https://pypi.org), as well as latest or git. Note that git versions may be unstable and are generally not recommended.
 
 ## Example
 
@@ -133,4 +132,3 @@ All commands, along with the installed versions and set paths, as well as the co
 ## Links
 
 - [PsychoPy Github](https://github.com/psychopy/psychopy)
-- [PsychoPy_bids GitLab](https://gitlab.com/psygraz/psychopy-bids)

--- a/psychopy_linux_installer
+++ b/psychopy_linux_installer
@@ -15,7 +15,7 @@ Usage: ./psychopy_linux_installer [options]
 Options:
   --psychopy-version=VERSION                    Specify PsychoPy version (default: 2024.1.4).
   --python-version=3.8|3.9|3.10                 Specify Python version (default: 3.10).
-  --use-system-python                           Use the system-installed Python instead of installing a new version. Requires Python (version 3.*), pip, and venv to be pre-installed and accessible in the system path.
+  --existing-python                             Use existing Python version instead of installing a new one. Requires chosen Python version, pip, and venv to be pre-installed and accessible in the system path.
   --wxpython-version=VERSION                    Specify wxPython version (default: 4.2.2).
   --build=[python|wxpython|both]                Build Python and/or wxPython from source instead of downloading.
   --install-dir=DIR                             Specify installation directory (default: "$HOME").
@@ -571,7 +571,7 @@ add_psychopy_to_path() {
 main() {
     psychopy_version="2024.1.4"
     python_version="3.10"
-    use_system_python=false
+    existing_python=false
     wxpython_version="4.2.2"
     build_python=false
     build_wx=false
@@ -598,8 +598,8 @@ main() {
                     exit 1
                 fi
                 ;;
-            --use-system-python)
-                use_system_python=true
+            --existing-python)
+                existing_python=true
                 ;;
             --wxpython-version=*)
                 wxpython_version="${arg#*=}"
@@ -674,9 +674,9 @@ main() {
     processor_structure=$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m)
     log_message "Info: Initiating PsychoPy(${psychopy_version}) installation on ${os_version} (${processor_structure})."
 
-    # Exit if --use-system-python flag used but python not in path.
-    if [ "$use_system_python" = true ] && ! command -v "python${python_version}" > /dev/null 2>&1; then
-        log_message "Error: Python${python_version} not in path use without --use-system-python to install Python. Exiting."
+    # Exit if --existing-python flag used but python not in path.
+    if [ "$existing_python" = true ] && ! command -v "python${python_version}" > /dev/null 2>&1; then
+        log_message "Error: Python${python_version} not in path use without --existing-python to install Python. Exiting."
         exit 1
     fi
 
@@ -732,7 +732,7 @@ main() {
         exit 1
     fi
     
-    if [ "$use_system_python" = false ]; then
+    if [ "$existing_python" = false ]; then
         if [ "$build_python" = true ]; then
             build_python
         else


### PR DESCRIPTION
This PR adds the `--existing-python` flag, allowing users to skip Python setup by using an existing Python installation (with pip and venv) in the system path.